### PR TITLE
hard one

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,8 +16,12 @@ class IntegerRange:
     def __set__(self,
                 instance: type[SlideLimitationValidator],
                 value: int) -> None:
+        if not isinstance(value, (int, float)):
+            raise TypeError("Value can only be int or float")
         if not self.min_amount <= value <= self.max_amount:
-            return setattr(instance, self.protected_name, False)
+            raise ValueError(f"The value of *{self.protected_name[1:]}* "
+                             f"should be in range({self.min_amount} - "
+                             f"{self.max_amount}). Yours ({value})")
         setattr(instance, self.protected_name, value)
 
     def __set_name__(self,
@@ -68,8 +72,12 @@ class Slide:
         self.limitation_class = limitation_class
 
     def can_access(self, visitor: Visitor) -> bool:
-        lim = self.limitation_class(age=visitor.age,
-                                    height=visitor.height,
-                                    weight=visitor.weight)
-
-        return (lim.age and lim.weight and lim.height) is not False
+        try:
+            self.limitation_class(age=visitor.age,
+                                  height=visitor.height,
+                                  weight=visitor.weight)
+        except ValueError as e:
+            print(e)
+            return False
+        else:
+            return True

--- a/app/main.py
+++ b/app/main.py
@@ -76,7 +76,6 @@ class Slide:
             self.limitation_class(age=visitor.age,
                                   height=visitor.height,
                                   weight=visitor.weight)
-        except ValueError as e:
-            print(e)
+        except ValueError:
             return False
         return True

--- a/app/main.py
+++ b/app/main.py
@@ -79,5 +79,4 @@ class Slide:
         except ValueError as e:
             print(e)
             return False
-        else:
-            return True
+        return True

--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,7 @@ class IntegerRange:
                 value: int) -> None:
         if not isinstance(value, (int, float)):
             raise TypeError("Value can only be int or float")
-        if not self.min_amount <= value <= self.max_amount:
+        elif not self.min_amount <= value <= self.max_amount:
             raise ValueError(f"The value of *{self.protected_name[1:]}* "
                              f"should be in range({self.min_amount} - "
                              f"{self.max_amount}). Yours ({value})")

--- a/app/main.py
+++ b/app/main.py
@@ -1,25 +1,75 @@
+from __future__ import annotations
+
 from abc import ABC
 
 
 class IntegerRange:
-    pass
+    def __init__(self, min_amount: int, max_amount: int) -> None:
+        self.min_amount = min_amount
+        self.max_amount = max_amount
+
+    def __get__(self,
+                instance: type[SlideLimitationValidator],
+                owner: SlideLimitationValidator) -> int | None:
+        return getattr(instance, self.protected_name)
+
+    def __set__(self,
+                instance: type[SlideLimitationValidator],
+                value: int) -> None:
+        if not self.min_amount <= value <= self.max_amount:
+            return setattr(instance, self.protected_name, False)
+        setattr(instance, self.protected_name, value)
+
+    def __set_name__(self,
+                     owner: SlideLimitationValidator,
+                     name: str) -> None:
+        self.protected_name = "_" + name
 
 
 class Visitor:
-   pass
+    def __init__(self,
+                 name: str,
+                 age: int,
+                 weight: int,
+                 height: int) -> None:
+        self.name = name
+        self.age = age
+        self.weight = weight
+        self.height = height
 
 
 class SlideLimitationValidator(ABC):
-    pass
+    def __init__(self,
+                 age: int,
+                 weight: int,
+                 height: int) -> None:
+        self.age = age
+        self.weight = weight
+        self.height = height
 
 
 class ChildrenSlideLimitationValidator(SlideLimitationValidator):
-    pass
+    age = IntegerRange(4, 14)
+    height = IntegerRange(80, 120)
+    weight = IntegerRange(20, 50)
 
 
 class AdultSlideLimitationValidator(SlideLimitationValidator):
-    pass
+    age = IntegerRange(14, 60)
+    height = IntegerRange(120, 220)
+    weight = IntegerRange(50, 120)
 
 
 class Slide:
-    pass
+    def __init__(self,
+                 name: str,
+                 limitation_class: type[SlideLimitationValidator]) -> None:
+        self.name = name
+        self.limitation_class = limitation_class
+
+    def can_access(self, visitor: Visitor) -> bool:
+        lim = self.limitation_class(age=visitor.age,
+                                    height=visitor.height,
+                                    weight=visitor.weight)
+
+        return (lim.age and lim.weight and lim.height) is not False


### PR DESCRIPTION
I gotta admit that I stucked at this one for a long time, frist of all I didn't know how to handle ```raise``` cause we didn't learn ```try/except``` yet and I decided just to set the attribute to ```False``` so it's easy to handle later and no error occurs in tests. Of course I could use ```try/except``` but I thought it's not how it ment to be written. If you have a suggestion how we can handle it better without using ```try/except``` I would listen to it, or if you want me to rewrite it to ```try/except``` with ```raise``` just tell.
![NVIDIA_Share_aVRnnTsdHN](https://github.com/mate-academy/py-aquapark/assets/13889031/00aee7a2-eff6-4b25-a752-faf9e4873f93)

And this isn't even stopping here, I don't know if I put right type annotations cause with these ```get/set``` methods it's getting harder to keep track of annotations.

And one of the hardest parts that I had "cheat" (check someones else pull request) cause we aren't inheriting ```Visitor``` class to ```ChildrenSlideLimitationValidator / AdultSlideLimitationValidator``` and not even their parent class ```SlideLimitationValidator(ABC)``` inherit it. I didn't know how to fill them right I was trying to do something like this:
![NVIDIA_Share_L5IavdyNQd](https://github.com/mate-academy/py-aquapark/assets/13889031/1f01b19c-a5df-442a-8d50-be647f523c6d)

But it wasn't right cause we aren't inheriting ```Visitor``` class and I didn't know what's wrong with my code and what is the other way to pass that ```Visit``` class data, so I looked at one of students pull request to figure it out, it appeared that it to be like this, it made me feel bad that I didn't see it:
![NVIDIA_Share_Hoj80pAsAs](https://github.com/mate-academy/py-aquapark/assets/13889031/1c1de972-a465-4392-a4a4-ef0386d60e68)

Overall it feels like I had lots of pain with this task and I'll have to rewrite some of it cause it doesn't seem really good ;(